### PR TITLE
docs: http2ServerPush is destructed, so previous worker example is not a good example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,7 +44,24 @@ Then, simply import `handleEvent` in your worker entry point:
 import { handleEvent } from 'vitedge/worker'
 
 addEventListener('fetch', (event) => {
-  event.respondWith(handleEvent(event))
+  try {
+    event.respondWith(
+      handleEvent(event, {
+        http2ServerPush: {
+          destinations: ['style'],
+        },
+        willRequestApi({ url, query }) {
+          console.log('API:', url.pathname, query)
+        },
+      })
+    )
+  } catch (error) {
+    event.respondWith(
+      new Response(error.message || error.toString(), {
+        status: 500,
+      })
+    )
+  }
 })
 ```
 


### PR DESCRIPTION
…t a good example

```
Uncaught (in promise)
TypeError: Cannot destructure property 'http2ServerPush' of 'undefined' as it is undefined.
    at T (worker.js:30:9231)
    at worker.js:30:10550
Uncaught (in response)
TypeError: Cannot destructure property 'http2ServerPush' of 'undefined' as it is undefined.
```

Another alternative is the code could be `event.respondWith(handleEvent(event, {}))`, or ... (I'll make another PR)